### PR TITLE
Calculate N on the fly

### DIFF
--- a/src/main/java/SEIRS.java
+++ b/src/main/java/SEIRS.java
@@ -152,6 +152,7 @@ class SEIRS {
         f.write(ByteBuffer.wrap(line.getBytes(StandardCharsets.UTF_8)));
 
         for (int i = 0; i < time_steps; i++) {
+            N = S[i] + E[i] + I[i] + R[i];
             double dSdt  = mu_d*N - (beta*S[i]*I[i])/N + omega_d*R[i]  - mu_d*S[i]; 
             double dEdt  = -sigma_d*E[i]  + (beta*S[i]*I[i])/N - mu_d*E[i];
             double dIdt  = -gamma_d*I[i]  + sigma_d*E[i]  - (mu_d+alpha)*I[i];


### PR DESCRIPTION
@B0SKAMP - just a quick fix to the model - N should be calculated on the fly because `alpha` may not be zero (though it is in the example, so it doesn't matter in this example). Everyone had missed this in all of the models! If that looks like it doesn't break anything, can you merge it please?